### PR TITLE
Set group rw permission for /dev/ipu-psys0

### DIFF
--- a/config/50-earlyapp.rules
+++ b/config/50-earlyapp.rules
@@ -1,3 +1,4 @@
 KERNEL=="cbc-early-signals" GROUP="ias" MODE="660"
 KERNEL=="intel_pipeline" GROUP="ias" MODE="660"
 KERNEL=="intel_stream*" GROUP="ias" MODE="660"
+KERNEL=="ipu-psys0" GROUP="ias" MODE="660"

--- a/config/earlyapp-setup.service
+++ b/config/earlyapp-setup.service
@@ -12,8 +12,8 @@ ExecStart=/usr/bin/modprobe -a crlmodule-lite intel-ipu4 intel-ipu4-mmu intel-ip
 # Initialize GPIO device node
 ExecStart=/usr/share/earlyapp/kpi_gpio.sh 442
 # Set permissions on CBC, GPIO, and ICI device nodes
-ExecStart=/usr/bin/chown :ias /dev/cbc-early-signals /sys/class/gpio/gpio442/value /dev/intel_stream27 /dev/intel_pipeline
-ExecStart=/usr/bin/chmod g+rw /dev/cbc-early-signals /sys/class/gpio/gpio442/value /dev/intel_stream27 /dev/intel_pipeline
+ExecStart=/usr/bin/chown :ias /dev/cbc-early-signals /sys/class/gpio/gpio442/value /dev/intel_stream27 /dev/intel_pipeline /dev/ipu-psys0
+ExecStart=/usr/bin/chmod g+rw /dev/cbc-early-signals /sys/class/gpio/gpio442/value /dev/intel_stream27 /dev/intel_pipeline /dev/ipu-psys0
 # Set permissions on GPU render nodes
 ExecStart=/usr/bin/chown :render /dev/dri/renderD128
 ExecStart=/usr/bin/chmod g+rw /dev/dri/renderD128


### PR DESCRIPTION
Required when using both `--use-gstreamer` and `--camera-input ici`