### PR TITLE
Allow installing earlyapp_gst.service

### DIFF
--- a/config/earlyapp_gst.service
+++ b/config/earlyapp_gst.service
@@ -12,3 +12,6 @@ ExecStart=/usr/bin/earlyapp --rvc-sound /usr/share/earlyapp/beep.wav --use-gstre
 Slice=earlyapp.slice
 User=ias
 SupplementaryGroups=video render
+
+[Install]
+Alias=earlyapp.service


### PR DESCRIPTION
Replaces earlyapp.service at runtime using Alias=

To test: `systemctl enable earlyapp_gst`. On next reboot, `systemctl status earlyapp` shows earlyapp_gst.service is run.