### PR TITLE
Separate IPU module loading into another service

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -31,6 +31,7 @@ SET(CONF_FILES
     ias-earlyapp-setup.service
     earlyapp_resume.service
     earlyapp-setup.service
+    earlyapp-setup-ipu.service
     fb_splash.service
     simple-egl.service
     simple-egl_resume.service)

--- a/config/earlyapp-setup-ipu.service
+++ b/config/earlyapp-setup-ipu.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Setup IPU device nodes for Early App
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Slice=earlyapp.slice
+
+# Load IPU/ICI modules
+ExecStart=/usr/bin/modprobe -a crlmodule-lite intel-ipu4 intel-ipu4-mmu intel-ipu4-psys ici-isys-mod intel-ipu4-psys-csslib intel-ipu4-isys-csslib
+# Set permissions on ICI device nodes
+ExecStart=/usr/bin/chown :ias /dev/intel_stream27 /dev/intel_pipeline /dev/ipu-psys0
+ExecStart=/usr/bin/chmod g+rw /dev/intel_stream27 /dev/intel_pipeline /dev/ipu-psys0

--- a/config/earlyapp-setup.service
+++ b/config/earlyapp-setup.service
@@ -1,4 +1,5 @@
 [Unit]
+Description=Setup device nodes for Early App
 DefaultDependencies=no
 After=cbc_attach.service
 
@@ -7,13 +8,11 @@ Type=oneshot
 RemainAfterExit=yes
 Slice=earlyapp.slice
 
-# Load IPU/ICI modules
-ExecStart=/usr/bin/modprobe -a crlmodule-lite intel-ipu4 intel-ipu4-mmu intel-ipu4-psys ici-isys-mod intel-ipu4-psys-csslib intel-ipu4-isys-csslib
 # Initialize GPIO device node
 ExecStart=/usr/share/earlyapp/kpi_gpio.sh 442
-# Set permissions on CBC, GPIO, and ICI device nodes
-ExecStart=/usr/bin/chown :ias /dev/cbc-early-signals /sys/class/gpio/gpio442/value /dev/intel_stream27 /dev/intel_pipeline /dev/ipu-psys0
-ExecStart=/usr/bin/chmod g+rw /dev/cbc-early-signals /sys/class/gpio/gpio442/value /dev/intel_stream27 /dev/intel_pipeline /dev/ipu-psys0
+# Set permissions on CBC and GPIO device nodes
+ExecStart=/usr/bin/chown :ias /dev/cbc-early-signals /sys/class/gpio/gpio442/value
+ExecStart=/usr/bin/chmod g+rw /dev/cbc-early-signals /sys/class/gpio/gpio442/value
 # Set permissions on GPU render nodes
 ExecStart=/usr/bin/chown :render /dev/dri/renderD128
 ExecStart=/usr/bin/chmod g+rw /dev/dri/renderD128

--- a/config/earlyapp.service
+++ b/config/earlyapp.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=GP2.0 Early application
 DefaultDependencies=no
-Requires=ias-earlyapp.service cbc_attach.service earlyapp-setup.service
-After=ias-earlyapp.service cbc_attach.service earlyapp-setup.service
+Requires=ias-earlyapp.service cbc_attach.service earlyapp-setup.service earlyapp-setup-ipu.service
+After=ias-earlyapp.service cbc_attach.service earlyapp-setup.service earlyapp-setup-ipu.service
 
 [Service]
 Environment=XDG_RUNTIME_DIR=/run/ias


### PR DESCRIPTION
IPU only applies to GP platform, therefore only load as dependency of
earlyapp.service. Other platforms may use earlyapp_gst.service which
uses V4L2 instead.