### PR TITLE
Support custom GStreamer camera pipeline command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ https://opensource.org/licenses/MIT
 ## Program options
  - --help: Show usage.
  - -v [ --version ]: Print version number.
- - -c [ --camera-input ] &lt;cam input&gt; Camera input source selection, only supported with use-gstreamer option. 
+ - -c [ --camera-input ] &lt;cam input&gt; Camera input source selection. Only supported with use-gstreamer option.
  - -s [--splash-video] &lt;file path&gt;: Set splash video path.
  - -d [--cbc-device] &lt;device path&gt;: Set CBC device path.
  - --bootup-sound &lt;file path&gt;: Set bootup sound path.
@@ -32,6 +32,7 @@ https://opensource.org/licenses/MIT
  - --gpio-number &lt;number&gt;: GPIO number for KPI measurements. Negative values will be ignored.
  - --gpio-sustain &lt;number&gt;: GPIO sustaining time in ms for KPI measurements.
  - --use-gstreamer : Use GStreamer for auido, camera and video.
+ - --gstcamcmd &lt;custom definition&gt;: Custom GStreamer camera command. Only supported with use-gstreamer option.
 
 
 ## Building

--- a/include/Configuration.hpp
+++ b/include/Configuration.hpp
@@ -59,6 +59,7 @@ namespace earlyapp
         static const int DEFAULT_GPIONUMBER;
         static const useconds_t DEFAULT_GPIOSUSTAIN;
         static const bool DEFAULT_USE_GSTREAMER;
+        static const char* DEFAULT_GSTCAMCMD;
 
 
         /*
@@ -75,6 +76,7 @@ namespace earlyapp
         static const char* KEY_GPIONUMBER;
         static const char* KEY_GPIOSUSTAIN;
         static const char* KEY_USEGSTREAMER;
+        static const char* KEY_GSTCAMCMD;
 
 
         /**
@@ -162,6 +164,11 @@ namespace earlyapp
            @brief Returns whether user asked to use GStreamer.
         */
         bool useGStreamer(void) const;
+
+        /**
+           @brief Returns GStreamer camera custom command.
+         */
+        const std::string& gstCamCmd(void);
 
         /**
            @brief Disable copy assigned operators.

--- a/include/DeviceController.hpp
+++ b/include/DeviceController.hpp
@@ -62,11 +62,13 @@ namespace earlyapp
            @param pAud Audio device instance.
            @param pVid Video device instance.
            @param pCam Camera device instance.
+           @param bWaitWL Wait for wayland socket before initialize devices.
         */
-        virtual void init(
+        void init(
             OutputDevice* pAud=nullptr,
             OutputDevice* pVid=nullptr,
-            OutputDevice* pCam=nullptr);
+            OutputDevice* pCam=nullptr,
+            bool bWaitWL = true);
 
         /**
            @brief Control devices.

--- a/include/GStreamerApp.hpp
+++ b/include/GStreamerApp.hpp
@@ -43,14 +43,6 @@ namespace earlyapp
          */
         ~GStreamerApp(void);
 
-        /*
-          @brief Initializer
-          @param gstInitStr GStreamer initialization string.
-          @param createLoop True to create own loop.
-          @return true for successful initialization.
-        */
-        bool init(const char* gstInitStr, bool createLoop=true);
-
         /**
            @brief Initializer.
            @param gstPipeLine A pointer for a GStreamer pipeline.
@@ -80,10 +72,16 @@ namespace earlyapp
          */
         int displayWidth(void);
 
-        /*
+        /**
           @brief Returns display height
          */
         int displayHeight(void);
+
+        /**
+           @brief Returns GStreamer pipeline.
+         */
+        GstElement* gstPipeline(void) const { return m_pGSTPipeline; }
+
 
     protected:
         /**

--- a/include/GstCameraDevice.hpp
+++ b/include/GstCameraDevice.hpp
@@ -35,7 +35,7 @@ namespace earlyapp
     /**
       @brief A class abstracts camera device.
      */
-    class GstCameraDevice: public OutputDevice, GStreamerApp
+    class GstCameraDevice: public OutputDevice, public GStreamerApp
     {
     public:
         /**
@@ -64,6 +64,7 @@ namespace earlyapp
         */
         void terminate(void);
 
+
         /**
            @brief Destructor.
         */
@@ -81,6 +82,20 @@ namespace earlyapp
            @brief Default constructor hidden in preivate to prevent instancitation.
         */
         GstCameraDevice(void) { OutputDevice::m_pDevName = "Gst Camera"; }
+
+        /**
+           @brief Create a custom command GStreamer pipeline.
+           @param customGstCmd GStreamer command string for creating a pipeline.
+           @return A new camera pipeline, nullptr for errors.
+         */
+        GstElement* createPipelineFromString(std::string& customGstCmd);
+
+        /**
+           @brief Create a fixed GStreamer pipeline for ICI.
+           @param camInputSrc Camera input source.
+           @return A new camera pipeline, nullptr for errors.
+         */
+        GstElement* createFixedPipeline(std::string& camInputSrc);
 
         /**
            @brief Camear device instance.

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -47,7 +47,7 @@ namespace earlyapp
     // Default values.
     const char* Configuration::DEFAULT_AUDIO_SPLASHSOUND_PATH = "/usr/share/earlyapp/jingle.wav";
     const char* Configuration::DEFAULT_AUDIO_RVCSOUND_PATH = "/usr/share/earlyapp/beep.wav";
-    const char* Configuration::DEFAULT_CAMERA_INPUTSOURCE = "ici";
+    const char* Configuration::DEFAULT_CAMERA_INPUTSOURCE = "icam";
     const char* Configuration::DEFAULT_VIDEO_SPLASH_PATH = "/usr/share/earlyapp/splash_video.h264";
     const char* Configuration::DEFAULT_CBCDEVICE_PATH = "/dev/cbc-early-signals";
     const char* Configuration::DEFAULT_TESTCBCDEVICE_PATH = "";
@@ -56,6 +56,7 @@ namespace earlyapp
     const int Configuration::DEFAULT_GPIONUMBER = NOT_SET;
     const unsigned int Configuration::DEFAULT_GPIOSUSTAIN = 1;
     const bool Configuration::DEFAULT_USE_GSTREAMER = false;
+    const char* Configuration::DEFAULT_GSTCAMCMD = "";
 
 
     // Configuration keys.
@@ -70,6 +71,7 @@ namespace earlyapp
     const char* Configuration::KEY_GPIONUMBER = "gpio-number";
     const char* Configuration::KEY_GPIOSUSTAIN = "gpio-sustain";
     const char* Configuration::KEY_USEGSTREAMER = "use-gstreamer";
+    const char* Configuration::KEY_GSTCAMCMD = "gstcamcmd";
 
 
 
@@ -151,7 +153,7 @@ namespace earlyapp
 
     const std::string& Configuration::stringMappedValueOf(const char* key)
     {
-        static const std::string nullStr = std::string("null");
+        static const std::string nullStr = std::string("");
         const std::string* valueStr;
 
         try
@@ -197,8 +199,14 @@ namespace earlyapp
     // Use GStreamer
     bool Configuration::useGStreamer(void) const
     {
-        unsigned int useGStreamer = m_VM[Configuration::KEY_USEGSTREAMER].as<bool>();
+        bool useGStreamer = m_VM[Configuration::KEY_USEGSTREAMER].as<bool>();
         return useGStreamer;
+    }
+
+    // GStreamer camera custom command.
+    const std::string& Configuration::gstCamCmd(void)
+    {
+        return stringMappedValueOf(Configuration::KEY_GSTCAMCMD);
     }
 
     // Destructor.
@@ -229,7 +237,7 @@ namespace earlyapp
                 // NOTE: Camera source option is supported with GStreamer.
                 ("camera-input,c",
                  boost::program_options::value<std::string>()->default_value(Configuration::DEFAULT_CAMERA_INPUTSOURCE)->notifier(&checkCameraParameter),
-                 "Camera input source selection, only supported with use-gstreamer option.")
+                 "Camera input source selection. Only supported with use-gstreamer option.")
 
                 // Splash video.
                 ("splash-video,s",
@@ -279,14 +287,19 @@ namespace earlyapp
                 // Use GStreamer
                 (Configuration::KEY_USEGSTREAMER,
                  boost::program_options::bool_switch()->default_value(Configuration::DEFAULT_USE_GSTREAMER),
-                 "Use GStreamer for auido, camera and video.");
+                 "Use GStreamer for auido, camera and video.")
+
+                // Custom GStreamer camera command.
+                (Configuration::KEY_GSTCAMCMD,
+                 boost::program_options::value<std::string>()->default_value(Configuration::DEFAULT_GSTCAMCMD),
+                 "Custom GStreamer camera command. Only supported with use-gstreamer option.");
 
 
             boost::program_options::store(
                 boost::program_options::parse_command_line(argc, argv, *m_pDesc), m_VM);
             boost::program_options::notify(m_VM);
 
-            // Help.
+             // Help.
             if(m_VM.count("help"))
             {
                 m_Valid = false;
@@ -322,7 +335,7 @@ namespace earlyapp
     {
         // Supported camera options.
         if(
-            optStr.compare("ici") != 0
+            optStr.compare("icam") != 0
             && optStr.compare("v4l2") != 0
             && optStr.compare("test") != 0)
         {

--- a/src/DeviceController.cpp
+++ b/src/DeviceController.cpp
@@ -69,7 +69,7 @@ namespace earlyapp
     /*
       Initialize device controller.
      */
-    void DeviceController::init(OutputDevice* pAud, OutputDevice* pVid, OutputDevice* pCam)
+    void DeviceController::init(OutputDevice* pAud, OutputDevice* pVid, OutputDevice* pCam, bool bWaitWL)
     {
         if(m_pSST == nullptr)
         {
@@ -104,7 +104,8 @@ namespace earlyapp
         dmesgLogPrint("EA: Waiting for Wayland socket...");
 #endif
         // Wait for the Wayland.
-        waitForWayland();
+        if(bWaitWL)
+            waitForWayland();
 #ifdef USE_DMESGLOG
         dmesgLogPrint("EA: Got Wayland compositor socket.");
 #endif

--- a/src/EALog.cpp
+++ b/src/EALog.cpp
@@ -1,23 +1,26 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
-// Copyright Intel Corporation All Rights Reserved.
+// Copyright (C) 2018 Intel Corporation
 //
-// The source code, information and material ("Material") contained herein is
-// owned by Intel Corporation or its suppliers or licensors, and title to such
-// Material remains with Intel Corporation or its suppliers or licensors. The
-// Material contains proprietary information of Intel or its suppliers and
-// licensors. The Material is protected by worldwide copyright laws and treaty
-// provisions. No part of the Material may be used, copied, reproduced,
-// modified, published, uploaded, posted, transmitted, distributed or disclosed
-// in any way without Intel's prior express written permission. No license under
-// any patent, copyright or other intellectual property rights in the Material
-// is granted to or conferred upon you, either expressly, by implication,
-// inducement, estoppel or otherwise. Any license under such intellectual
-// property rights must be express and approved by Intel in writing.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom
+// the Software is furnished to do so, subject to the following conditions:
 //
-// Unless otherwise agreed by Intel in writing, you may not remove or alter this
-// notice or any other notice embedded in Materials by Intel or Intel's
-// suppliers or licensors in any way."
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+// OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
 //
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/GStreamerApp.cpp
+++ b/src/GStreamerApp.cpp
@@ -46,23 +46,6 @@ namespace earlyapp
         }
     }
 
-    /*
-      Intialize
-    */
-    bool GStreamerApp::init(const char* gstInitStr, bool createLoop)
-    {
-        LINF_(TAG, "Initializing GStreamerApp...");
-        m_bCreateLoop = createLoop;
-
-        LINF_(TAG, "Launching string: " << gstInitStr);
-        if((m_pGSTPipeline = gst_parse_launch(gstInitStr, nullptr)) == nullptr)
-        {
-            LERR_(TAG, "Failed to GST launch.");
-            return false;
-        }
-
-        return true;
-    }
 
     /*
       Intialize
@@ -75,7 +58,7 @@ namespace earlyapp
 
         if(m_pGSTPipeline == nullptr)
         {
-            LERR_(TAG, "Pipe line is invalid.");
+            LERR_(TAG, "Pipeline is invalid.");
             return false;
         }
         return true;
@@ -92,7 +75,7 @@ namespace earlyapp
         // GST pipeline
         if(m_pGSTPipeline == nullptr)
         {
-            LERR_(TAG, "Pipeline is invalid");
+            LERR_(TAG, "Pipeline is invalid(nullptr)");
             return;
         }
 


### PR DESCRIPTION
This patch implements a custom GStreamer camera pipeline
initialization option '--gstcamcmd' that allows user can specify own
custom GStreamer pipeline command for camera device instead of using
fixed camera pipeline.  Note that the '--use-gstreamer' option should
be given with this option.  Otherwise this opiton will be ignored.
This patch also includes changing of camera source selection option
from ici to icam since GStreamer plugin icamerasrc is not only for
ICI.

e.g) $ earlyapp --use-gstreamer --gstcamcmd "v4l2src ! waylandsink"

Change-Id: I3289bb8ae826a1766dc410724f84d0343958c03c
Signed-off-by: Hong, Brandon <brandon.hong@intel.com>