### PR TITLE
Change EALog.cpp license header

### DIFF
--- a/src/EALog.cpp
+++ b/src/EALog.cpp
@@ -1,23 +1,26 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
-// Copyright Intel Corporation All Rights Reserved.
+// Copyright (C) 2018 Intel Corporation
 //
-// The source code, information and material ("Material") contained herein is
-// owned by Intel Corporation or its suppliers or licensors, and title to such
-// Material remains with Intel Corporation or its suppliers or licensors. The
-// Material contains proprietary information of Intel or its suppliers and
-// licensors. The Material is protected by worldwide copyright laws and treaty
-// provisions. No part of the Material may be used, copied, reproduced,
-// modified, published, uploaded, posted, transmitted, distributed or disclosed
-// in any way without Intel's prior express written permission. No license under
-// any patent, copyright or other intellectual property rights in the Material
-// is granted to or conferred upon you, either expressly, by implication,
-// inducement, estoppel or otherwise. Any license under such intellectual
-// property rights must be express and approved by Intel in writing.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom
+// the Software is furnished to do so, subject to the following conditions:
 //
-// Unless otherwise agreed by Intel in writing, you may not remove or alter this
-// notice or any other notice embedded in Materials by Intel or Intel's
-// suppliers or licensors in any way."
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+// OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// SPDX-License-Identifier: MIT
 //
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Replaced old license header with SPDX MIT license identifier.

Signed-off-by: Brandon Hong <brandon.hong@intel.com>