### PR TITLE
improve earlyapp schedule priority

### DIFF
--- a/config/earlyapp-setup.service
+++ b/config/earlyapp-setup.service
@@ -16,3 +16,4 @@ ExecStart=/usr/bin/chmod g+rw /dev/cbc-early-signals /sys/class/gpio/gpio442/val
 # Set permissions on GPU render nodes
 ExecStart=/usr/bin/chown :render /dev/dri/renderD128
 ExecStart=/usr/bin/chmod g+rw /dev/dri/renderD128
+Nice=-1

--- a/config/earlyapp.service
+++ b/config/earlyapp.service
@@ -12,3 +12,4 @@ ExecStart=/usr/bin/earlyapp --rvc-sound /usr/share/earlyapp/beep.wav --bootup-so
 Slice=earlyapp.slice
 User=ias
 SupplementaryGroups=video render
+Nice=-1


### PR DESCRIPTION
default nice is 0, set it to -1 to get a higher schedule priority. It help reduce
the latency jitter of earlyapp

Signed-off-by: jwang <jing.j.wang@intel.com>