### PR TITLE
Added earlyapp services that support UEFI env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Early Appls4
+# Early App
 
 ## Introduction
 This software is a testing application that runs on Clear Linux to verify

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Early App
+# Early Appls4
 
 ## Introduction
 This software is a testing application that runs on Clear Linux to verify
@@ -53,7 +53,6 @@ https://opensource.org/licenses/MIT
   $ src/earlyapp [options]
   ```
 
-
 ### Compilation options
  - USE_LOGOUTPUT
  : Enable detailed log output to standard out.
@@ -70,3 +69,20 @@ https://opensource.org/licenses/MIT
   ```
 
 
+## Earlyapp in UEFI environment
+
+1. Service enablement for splash video:
+
+  ```shell
+  $ sudo systemctl enable earlyapp_gst.target
+  ```
+
+2. Using camera on runtime
+
+   Pre-requisite: export XDG_RUNTIME_DIR, WAYLAND_DISPLAY and GST_PLUGIN_PATH
+
+  ```shell
+  $ src/earlyapp --use-gstreamer --camera-input test 
+  ```
+
+To use earlyapp with CBC please refer to our Early App user guide. 

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -26,11 +26,13 @@
 # Resource files.
 SET(CONF_FILES
     earlyapp.target
+    earlyapp_gst.target
     earlyapp.slice
     ias-earlyapp.service
     ias-earlyapp-setup.service
     earlyapp_resume.service
     earlyapp-setup.service
+    earlyapp-setup_gst.service
     earlyapp-setup-ipu.service
     simple-egl.service
     simple-egl_resume.service)

--- a/config/earlyapp-setup_gst.service
+++ b/config/earlyapp-setup_gst.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Setup device nodes for Early App
+DefaultDependencies=no
+After=cbc_attach.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Slice=earlyapp.slice
+
+# Set permissions on GPU render nodes
+ExecStart=/usr/bin/chown :render /dev/dri/renderD128
+ExecStart=/usr/bin/chmod g+rw /dev/dri/renderD128

--- a/config/earlyapp_gst.service
+++ b/config/earlyapp_gst.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=GP2.0 Early application
 DefaultDependencies=no
-Requires=ias-earlyapp.service cbc_attach.service earlyapp-setup.service
-After=ias-earlyapp.service cbc_attach.service earlyapp-setup.service
+Requires=ias-earlyapp.service cbc_attach.service earlyapp-setup_gst.service
+After=ias-earlyapp.service cbc_attach.service earlyapp-setup_gst.service
 
 [Service]
 Environment=XDG_RUNTIME_DIR=/run/ias

--- a/config/earlyapp_gst.target
+++ b/config/earlyapp_gst.target
@@ -1,0 +1,11 @@
+[Unit]
+Description=earlyapp target
+Wants=earlyapp_gst.service
+After=earlyapp_gst.service
+
+# Delay some heavier services to speed up earlyapp loading
+Before=systemd-udevd.service systemd-udev-trigger.service systemd-modules-load.service
+
+[Install]
+WantedBy=basic.target
+Also=earlyapp_resume.service

--- a/config/earlyapp_gst.target
+++ b/config/earlyapp_gst.target
@@ -1,5 +1,5 @@
 [Unit]
-Description=earlyapp target
+Description=earlyapp target for gstreamer
 Wants=earlyapp_gst.service
 After=earlyapp_gst.service
 


### PR DESCRIPTION
 1. Added earlyapp_gst.target that will call earlyapp_gst.service
 2. Changed earlyapp_gst.service that calls earlyapp-setup_gst.service
 3. Created new earlyapp-setup_gst.service that will not include initialization of GPIO device node and setting permission for GPIO device node.

This is due to GPIO_SYSFS is not set in kernel native and will cause earlyapp-setup.service to fail

Signed-off-by: candrew <clement@intel.com>