### PR TITLE
Remove earlyapp_resume.service

### DIFF
--- a/config/earlyapp.target
+++ b/config/earlyapp.target
@@ -8,4 +8,3 @@ Before=systemd-udevd.service systemd-udev-trigger.service systemd-modules-load.s
 
 [Install]
 WantedBy=basic.target
-Also=earlyapp_resume.service


### PR DESCRIPTION
As earlyapp should continue to work when resume from suspend,
we do not need to re-init it.

Signed-off-by: Liu Jianjun <jianjun.liu@intel.com>