### PR TITLE
config: add memory hotplug service

### DIFF
--- a/config/mem_hot_add.service
+++ b/config/mem_hot_add.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Memory hot add service
+Before=acrnd.service acrn_guest.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/bash /usr/bin/mem_hot_add.sh
+Restart=no
+
+[Install]
+WantedBy=multi-user.target

--- a/config/mem_hot_add.sh
+++ b/config/mem_hot_add.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#set -x
+
+grep "mem=4096" /proc/cmdline > /dev/null || exit
+addr=0x100000000
+
+cd /sys/devices/system/memory
+
+function online_memsec()
+{
+	addr=$1
+	echo $addr > probe 
+	let index=addr/0x8000000
+	echo online > memory$index/state 
+}
+
+# mem section is 256MB each, and the physical addr range
+# is from 0x100000000 - 0x280000000 (4G - 10G)
+for i in `seq 1 48`
+do
+	online_memsec $addr 
+	let addr=addr+0x8000000
+done
+
+wait
+
+
+


### PR DESCRIPTION
This is to save ther kernel boot time by utilizing kernel's
memory hotplug feature.

This will only take effect when there is a "mem=4096m" in
the kernel boot cmdline.

Signed-off-by: Feng Tang <feng.tang@intel.com>