### PR TITLE
Service files for GP native

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -27,12 +27,14 @@
 SET(CONF_FILES
     earlyapp.target
     earlyapp_gst.target
+    earlyapp_gpnative.target
     earlyapp.slice
     ias-earlyapp.service
     ias-earlyapp-setup.service
     earlyapp_resume.service
     earlyapp-setup.service
     earlyapp-setup_gst.service
+    earlyapp-setup_gpnative.service
     earlyapp-setup-ipu.service
     earlyapp-setup-audio.service
     simple-egl.service
@@ -42,6 +44,7 @@ SET(CONF_FILES
 # GStreamer base devices require different settings.
 SET(EAS_TARGET earlyapp.service)
 SET(EAS_SRC
+    earlyapp_gpnative.service
     earlyapp_gst.service
     earlyapp.service)
 

--- a/config/earlyapp-setup_gpnative.service
+++ b/config/earlyapp-setup_gpnative.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Setup device nodes for Early App Gordon Peak native.
+DefaultDependencies=no
+After=cbc_attach.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Slice=earlyapp.slice
+
+# Set permissions on GPU render nodes
+ExecStart=/usr/bin/chown :render /dev/dri/renderD128
+ExecStart=/usr/bin/chmod g+rw /dev/dri/renderD128

--- a/config/earlyapp_gpnative.service
+++ b/config/earlyapp_gpnative.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Early App service file for Gordon Peak native.
+DefaultDependencies=no
+Requires=ias-earlyapp.service cbc_attach.service earlyapp-setup_gpnative.service
+Wants=earlyapp-setup-audio.service
+After=ias-earlyapp.service cbc_attach.service earlyapp-setup_gpnative.service
+
+[Service]
+Environment=XDG_RUNTIME_DIR=/run/ias
+Environment=WAYLAND_DISPLAY=wayland-0
+Environment=GST_PLUGIN_PATH=/usr/lib/gstreamer-1.0
+ExecStart=/usr/bin/earlyapp --rvc-sound /usr/share/earlyapp/beep.wav --use-gstreamer --bootup-sound /usr/share/earlyapp/jingle.wav --splash-video /usr/share/earlyapp/splash_video.mp4 --gstcamcmd “icamerasrc device-name=mondello-3 input-height=480 input-width=720 input-format=UYVY deinterlace-method=3 interlace-mode=7 ! ‘video/x-raw,format=NV12,height=1080,width=1920’ ! vaapipostproc !  waylandsink"
+
+Slice=earlyapp.slice
+User=ias
+SupplementaryGroups=video render
+
+[Install]
+Alias=earlyapp.service

--- a/config/earlyapp_gpnative.target
+++ b/config/earlyapp_gpnative.target
@@ -1,0 +1,11 @@
+[Unit]
+Description=earlyapp target for gstreamer
+Wants=earlyapp_gpnative.service
+After=earlyapp_gpnative.service
+
+# Delay some heavier services to speed up earlyapp loading
+Before=systemd-udevd.service systemd-udev-trigger.service systemd-modules-load.service
+
+[Install]
+WantedBy=basic.target
+Also=earlyapp_resume.service


### PR DESCRIPTION
Users can enable the service with _gpnative suffix.
 e.g)
 $> sudo systemctl enable earlyapp_gpnative.target

Signed-off-by: Brandon Hong <brandon.hong@intel.com>

Signed-off-by: pedapalapati <padmarao.edapalapati@intel.com>