### PR TITLE
move ipu4 modules loading thread ahead and avoid reading file to boost loading

### DIFF
--- a/config/ipu.conf
+++ b/config/ipu.conf
@@ -1,7 +1,0 @@
-crlmodule-lite
-intel-ipu4
-intel-ipu4-mmu
-intel-ipu4-psys
-ici-isys-mod
-intel-ipu4-psys-csslib
-intel-ipu4-isys-csslib

--- a/res/ipu.conf
+++ b/res/ipu.conf
@@ -1,7 +1,0 @@
-crlmodule-lite
-intel-ipu4
-intel-ipu4-mmu
-intel-ipu4-psys
-ici-isys-mod
-intel-ipu4-psys-csslib
-intel-ipu4-isys-csslib


### PR DESCRIPTION
move ipu4 modules loading thread ahead and avoid reading file with fixed module list to boost loading modules