### PR TITLE
config: remove earlyapp-setup-audio.service

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -36,7 +36,6 @@ SET(CONF_FILES
     earlyapp-setup_gst.service
     earlyapp-setup_gpnative.service
     earlyapp-setup-ipu.service
-    earlyapp-setup-audio.service
     simple-egl.service
     simple-egl_resume.service
     mem_hot_add.service)


### PR DESCRIPTION
remove earlyapp-setup-audio.service, and launch the
audio in earlyapp-fastboot, which is earlier.

Signed-off-by: jwang <jing.j.wang@intel.com>
Signed-off-by: Liu Jianjun <jianjun.liu@intel.com>