### PR TITLE
add early-audio.service when path is not fastboot

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -39,6 +39,7 @@ SET(CONF_FILES
     simple-egl.service
     simple-egl_resume.service
     cbc_attach.service
+    early-audio.service
     early-audio_resume.service
     mem_hot_add.service)
 

--- a/config/early-audio.service
+++ b/config/early-audio.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=GP2.0 Early Audio
+Before=systemd-modules-load.service
+
+[Service]
+ExecStart=/usr/share/earlyapp/early_audio.sh noplay
+
+[Install]
+WantedBy=basic.target

--- a/config/early_audio.sh
+++ b/config/early_audio.sh
@@ -21,4 +21,4 @@ do
 done
 
 # early audio test
-aplay -Dplughw:0,0 `dirname $0`/jingle.wav --duration 1
+[ "$1" = "noplay" ] || aplay -Dplughw:0,0 `dirname $0`/jingle.wav --duration 1


### PR DESCRIPTION
when use non-fastboot path, need enable early-audio service explicitly by $systemctl enable early-audio.service

Signed-off-by: jwang <jing.j.wang@intel.com>