### PR TITLE
To close earlyapp when suspend

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -32,6 +32,7 @@ SET(CONF_FILES
     ias-earlyapp.service
     ias-earlyapp-setup.service
     earlyapp_resume.service
+    earlyapp_suspend.service
     earlyapp-setup.service
     earlyapp-setup_gst.service
     earlyapp-setup_gpnative.service

--- a/config/earlyapp_suspend.service
+++ b/config/earlyapp_suspend.service
@@ -1,0 +1,8 @@
+[Unit]
+Before=suspend.target
+
+[Service]
+ExecStart=/usr/bin/systemctl stop earlyapp.service
+
+[Install]
+WantedBy=suspend.target


### PR DESCRIPTION
Close earlyapp when suspend to close camera streaming,
and it will restart again when resume.

Signed-off-by: Liu Jianjun <jianjun.liu@intel.com>