### PR TITLE
split earlyapp-setup.service to avoid it is in the critical-chain

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -33,7 +33,9 @@ SET(CONF_FILES
     ias-earlyapp-setup.service
     earlyapp_resume.service
     earlyapp_suspend.service
-    earlyapp-setup.service
+    earlyapp-setup-cbc.service
+    earlyapp-setup-render.service
+    earlyapp-setup-aud.service
     earlyapp-setup_gst.service
     earlyapp-setup_gpnative.service
     earlyapp-setup-ipu.service

--- a/config/earlyapp-setup-aud.service
+++ b/config/earlyapp-setup-aud.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Setup device nodes for Early App
+DefaultDependencies=no
+
+[Service]
+RemainAfterExit=yes
+Slice=earlyapp.slice
+
+# Set permission to playback audio
+ExecStart=/usr/bin/usermod -a -G audio ias

--- a/config/earlyapp-setup-cbc.service
+++ b/config/earlyapp-setup-cbc.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Setup device nodes for Early App
+DefaultDependencies=no
+Requires=cbc_attach.service
+After=cbc_attach.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Slice=earlyapp.slice
+
+# Initialize GPIO device node
+ExecStart=/usr/share/earlyapp/kpi_gpio.sh 442
+# Set permissions on CBC and GPIO device nodes
+ExecStart=/usr/bin/chown :ias /dev/cbc-early-signals /sys/class/gpio/gpio442/value
+ExecStart=/usr/bin/chmod g+rw /dev/cbc-early-signals /sys/class/gpio/gpio442/value

--- a/config/earlyapp-setup-render.service
+++ b/config/earlyapp-setup-render.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Setup device nodes for Early App
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Slice=earlyapp.slice
+
+# Set permissions on GPU render nodes
+ExecStart=/usr/bin/chown :render /dev/dri/renderD128
+ExecStart=/usr/bin/chmod g+rw /dev/dri/renderD128

--- a/config/earlyapp.service
+++ b/config/earlyapp.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=GP2.0 Early application
 DefaultDependencies=no
-Requires=ias-earlyapp.service cbc_attach.service earlyapp-setup.service earlyapp-setup-ipu.service
-After=ias-earlyapp.service cbc_attach.service earlyapp-setup.service earlyapp-setup-ipu.service
+Requires=ias-earlyapp.service cbc_attach.service earlyapp-setup-cbc.service earlyapp-setup-render.service earlyapp-setup-aud.service earlyapp-setup-ipu.service
+After=ias-earlyapp.service cbc_attach.service earlyapp-setup-cbc.service earlyapp-setup-render.service earlyapp-setup-aud.service earlyapp-setup-ipu.service
 
 [Service]
 Environment=XDG_RUNTIME_DIR=/run/ias


### PR DESCRIPTION
Signed-off-by: Wang, Long <long1.wang@intel.com>